### PR TITLE
feat: 新增 JSON-RPC（stdio）服务，供图形前端结构化驱动

### DIFF
--- a/src/conf.rs
+++ b/src/conf.rs
@@ -29,7 +29,8 @@ use crate::{
 };
 use clap::Args;
 
-#[derive(Args, Debug, Clone)]
+#[derive(Args, Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
 #[command(version)]
 pub struct ConfValuesArgs {
     /// 值
@@ -37,7 +38,12 @@ pub struct ConfValuesArgs {
     value: Vec<String>,
 }
 
-#[derive(Subcommand, Debug)]
+#[derive(Subcommand, Debug, Serialize, Deserialize)]
+#[serde(
+    tag = "type",
+    rename_all = "snake_case",
+    rename_all_fields = "snake_case"
+)]
 #[command(infer_subcommands = false)]
 pub enum Targets {
     /// 设置标题
@@ -57,7 +63,8 @@ pub enum Targets {
     Migrate,
 }
 
-#[derive(Args, Debug)]
+#[derive(Args, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
 #[command(version)]
 pub struct ConfArgs {
     /// 目标对象
@@ -65,7 +72,8 @@ pub struct ConfArgs {
     pub target: Targets,
 }
 
-#[derive(Args, Debug, Clone)]
+#[derive(Args, Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
 #[command(version)]
 pub struct ConfCustomArgs {
     /// 键

--- a/src/context.rs
+++ b/src/context.rs
@@ -3,7 +3,7 @@ use crate::config::lang::Language;
 use crate::config::msgs::LoadContext;
 use crate::prelude::*;
 use indicatif::MultiProgress;
-use std::sync::OnceLock;
+use std::sync::RwLock;
 
 #[derive(Debug, Clone)]
 pub enum CurrentLocation {
@@ -26,15 +26,23 @@ pub struct Context {
     pub languages: IndexMap<String, Language>,
 }
 
-pub static GLOBAL_CONTEXT: OnceLock<Context> = OnceLock::new();
+pub static GLOBAL_CONTEXT: RwLock<Option<&'static Context>> = RwLock::new(None);
 
+/// 初始化/重建全局上下文。
+///
+/// JSON-RPC 模式下每个请求可能切换工作目录并重新加载配置，因此允许
+/// 多次调用重建；旧上下文以 `Box::leak` 保活，避免调用方持有的
+/// `&'static Context` 悬垂（每次重建只泄漏一个很小的结构）。
 pub fn setup_context(x: Context) -> Result<()> {
-    if GLOBAL_CONTEXT.set(x).is_err() {
-        bail!("Already initialized");
-    }
+    let leaked: &'static Context = Box::leak(Box::new(x));
+    *GLOBAL_CONTEXT.write().unwrap() = Some(leaked);
     Ok(())
 }
 
 pub fn gctx() -> &'static Context {
-    GLOBAL_CONTEXT.get().expect("Not initialized")
+    try_gctx().expect("Not initialized")
+}
+
+pub fn try_gctx() -> Option<&'static Context> {
+    *GLOBAL_CONTEXT.read().unwrap()
 }

--- a/src/dmk.rs
+++ b/src/dmk.rs
@@ -11,7 +11,8 @@ use owo_colors::OwoColorize;
 use std::fmt;
 use std::time::Duration;
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
 pub enum Target {
     /// 正式测试数据
     Data,
@@ -137,7 +138,8 @@ impl DmkReporter for CliDmkReporter {
     }
 }
 
-#[derive(Debug, Clone, ValueEnum)]
+#[derive(Debug, Clone, ValueEnum, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
 pub enum DmkCommand {
     /// 生成（未生成的）数据
     Gen,
@@ -147,7 +149,8 @@ pub enum DmkCommand {
     Reset,
 }
 
-#[derive(Args, Debug)]
+#[derive(Args, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
 #[command(version)]
 pub struct DmkArgs {
     /// 目标类型

--- a/src/doc.rs
+++ b/src/doc.rs
@@ -9,7 +9,12 @@ pub mod format;
 pub mod rules;
 pub mod span;
 
-#[derive(Debug, Clone, Subcommand)]
+#[derive(Debug, Clone, Subcommand, Serialize, Deserialize)]
+#[serde(
+    tag = "type",
+    rename_all = "snake_case",
+    rename_all_fields = "snake_case"
+)]
 #[command(version)]
 #[command(infer_subcommands = false)]
 pub enum Targets {
@@ -24,7 +29,8 @@ pub enum Targets {
     Validate,
 }
 
-#[derive(Args, Debug, Clone)]
+#[derive(Args, Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
 #[command(version)]
 pub struct DocArgs {
     /// 生成的对象
@@ -36,7 +42,7 @@ pub fn main(args: DocArgs) -> Result<()> {
     match args.target {
         Targets::Format(args) => format::main(args)?,
         Targets::Check(args) => check::main(args)?,
-        Targets::Validate => println!("{}", gctx().loadctx.render_tree()),
+        Targets::Validate => msg!("{}", gctx().loadctx.render_tree()),
     }
 
     Ok(())

--- a/src/doc/check.rs
+++ b/src/doc/check.rs
@@ -1,9 +1,11 @@
 use crate::tuack_lib::doc::rules::*;
 use crate::{doc::rules::*, prelude::*};
 use clap::Args;
+use serde::{Deserialize, Serialize};
 use tuack_ng_parser::parse;
 
-#[derive(Args, Debug, Clone)]
+#[derive(Args, Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
 #[command(version)]
 pub struct CheckArgs {
     /// 解释这个规则
@@ -138,7 +140,7 @@ fn explain(id: String) -> Result<()> {
 
     for checker in checkers {
         if checker.manifest().name == id {
-            println!("规则 {}: {}", id, checker.manifest().description);
+            msg!("规则 {}: {}", id, checker.manifest().description);
             return Ok(());
         }
     }

--- a/src/doc/format.rs
+++ b/src/doc/format.rs
@@ -1,9 +1,11 @@
 use crate::tuack_lib::doc::rules::*;
 use crate::{config::CONFIG_FILE_NAME, doc::rules::*, prelude::*};
 use clap::Args;
+use serde::{Deserialize, Serialize};
 use tuack_ng_parser::parse;
 
-#[derive(Args, Debug, Clone)]
+#[derive(Args, Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
 #[command(version)]
 pub struct FormatArgs {
     /// 解释这个规则
@@ -73,7 +75,7 @@ fn explain(id: String) -> Result<()> {
 
     for formatter in formatters {
         if formatter.manifest().name == id {
-            println!("规则 {}: {}", id, formatter.manifest().description);
+            msg!("规则 {}: {}", id, formatter.manifest().description);
             return Ok(());
         }
     }

--- a/src/dump.rs
+++ b/src/dump.rs
@@ -5,13 +5,15 @@ use clap::ValueEnum;
 mod arbiter;
 mod lemon;
 
-#[derive(Debug, Clone, Copy, ValueEnum)]
+#[derive(Debug, Clone, Copy, ValueEnum, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
 pub enum Target {
     Lemon,
     Arbiter,
 }
 
-#[derive(Args, Debug)]
+#[derive(Args, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
 #[command(version)]
 pub struct DumpArgs {
     /// 渲染目标模板

--- a/src/generate.rs
+++ b/src/generate.rs
@@ -14,7 +14,12 @@ use std::io;
 
 const CONFIG_FILE_NAME: &str = "conf.json";
 
-#[derive(Debug, Clone, Subcommand)]
+#[derive(Debug, Clone, Subcommand, Serialize, Deserialize)]
+#[serde(
+    tag = "type",
+    rename_all = "snake_case",
+    rename_all_fields = "snake_case"
+)]
 #[command(version)]
 #[command(infer_subcommands = false)]
 pub enum Targets {
@@ -50,7 +55,8 @@ pub enum Targets {
     Complete(GenCompleteArgs),
 }
 
-#[derive(Args, Debug, Clone)]
+#[derive(Args, Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
 #[command(version)]
 pub struct GenStatementArgs {
     /// 对象名称
@@ -58,7 +64,8 @@ pub struct GenStatementArgs {
     name: Vec<String>,
 }
 
-#[derive(Args, Debug, Clone)]
+#[derive(Args, Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
 #[command(version)]
 pub struct GenConfirmArgs {
     /// 跳过确认提示
@@ -66,7 +73,8 @@ pub struct GenConfirmArgs {
     confirm: bool,
 }
 
-#[derive(Args, Debug, Clone)]
+#[derive(Args, Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
 #[command(version)]
 pub struct GenCompleteArgs {
     /// 对象名称
@@ -74,7 +82,8 @@ pub struct GenCompleteArgs {
     name: String,
 }
 
-#[derive(Args, Debug, Clone)]
+#[derive(Args, Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
 #[command(version)]
 pub struct GenArgs {
     /// 生成的对象

--- a/src/init.rs
+++ b/src/init.rs
@@ -11,7 +11,7 @@ use log4rs::{
 use crate::config::msgs::LoadContext;
 use crate::{config::load_config, context};
 use chrono::Local;
-use indicatif::MultiProgress;
+use indicatif::{MultiProgress, ProgressDrawTarget};
 use indicatif_log_bridge::LogWrapper;
 use owo_colors::OwoColorize;
 use std::panic::{self, PanicHookInfo};
@@ -58,23 +58,40 @@ fn custom_panic_handler(panic_info: &PanicHookInfo, verbose: bool) {
     panic_log!("详见：https://docs.tuack-ng.ink/app/faq/panic.html");
 }
 
-fn init_log(verbose: &bool) -> Result<MultiProgress> {
+pub(crate) fn init_log(verbose: &bool) -> Result<MultiProgress> {
     let format = if *verbose {
         "{d(%Y-%m-%d %H:%M:%S)} | {h({l})} | {t} | {m}{n}"
     } else {
         "{h({l})} | {m}{n}"
     };
 
-    let stdout = ConsoleAppender::builder()
-        .target(Target::Stderr)
-        .encoder(Box::new(PatternEncoder::new(format)))
-        .build();
-
     let loglevel = if *verbose {
         LevelFilter::Trace
     } else {
         LevelFilter::Warn
     };
+
+    // RPC 模式：日志与进度条均改道为通知（否则会污染 stdout 的 JSON 流）
+    if crate::rpc::is_enabled() {
+        let config = Config::builder()
+            .appender(Appender::builder().build("rpc", Box::new(RpcLogAppender)))
+            .build(Root::builder().appender("rpc").build(loglevel))?;
+
+        let logger: log4rs::Logger = Logger::new(config);
+        let level = logger.max_log_level();
+        let multi = MultiProgress::with_draw_target(ProgressDrawTarget::term_like(Box::new(
+            RpcTermLike::default(),
+        )));
+        LogWrapper::new(multi.clone(), logger).try_init().unwrap();
+        log::set_max_level(level);
+
+        return Ok(multi);
+    }
+
+    let stdout = ConsoleAppender::builder()
+        .target(Target::Stderr)
+        .encoder(Box::new(PatternEncoder::new(format)))
+        .build();
 
     let config = Config::builder()
         .appender(Appender::builder().build("stdout", Box::new(stdout)))
@@ -89,7 +106,73 @@ fn init_log(verbose: &bool) -> Result<MultiProgress> {
     Ok(multi)
 }
 
-fn init_context(multi: MultiProgress, migrating: bool, validating: bool) -> Result<()> {
+/// RPC 模式：log 输出转为 output 通知
+#[derive(Debug)]
+struct RpcLogAppender;
+
+impl log4rs::append::Append for RpcLogAppender {
+    fn append(&self, record: &log::Record) -> anyhow::Result<()> {
+        crate::rpc::emit_output("stderr", &format!("{} | {}", record.level(), record.args()));
+        Ok(())
+    }
+
+    fn flush(&self) {}
+}
+
+/// RPC 模式：捕获 indicatif 的绘制输出并转为 progress 通知。
+/// 多进度条场景仅保留最近绘制的一行（v1 简化）。
+#[derive(Debug, Default)]
+struct RpcTermLike {
+    line: std::sync::Mutex<String>,
+}
+
+impl indicatif::TermLike for RpcTermLike {
+    fn width(&self) -> u16 {
+        120
+    }
+
+    fn move_cursor_up(&self, _n: usize) -> std::io::Result<()> {
+        Ok(())
+    }
+
+    fn move_cursor_down(&self, _n: usize) -> std::io::Result<()> {
+        Ok(())
+    }
+
+    fn move_cursor_right(&self, _n: usize) -> std::io::Result<()> {
+        Ok(())
+    }
+
+    fn move_cursor_left(&self, _n: usize) -> std::io::Result<()> {
+        Ok(())
+    }
+
+    fn write_line(&self, s: &str) -> std::io::Result<()> {
+        *self.line.lock().unwrap() = s.trim_end_matches('\r').to_string();
+        Ok(())
+    }
+
+    fn write_str(&self, s: &str) -> std::io::Result<()> {
+        self.line.lock().unwrap().push_str(s);
+        Ok(())
+    }
+
+    fn clear_line(&self) -> std::io::Result<()> {
+        Ok(())
+    }
+
+    fn flush(&self) -> std::io::Result<()> {
+        let mut line = self.line.lock().unwrap();
+        let text = line.trim().to_string();
+        if !text.is_empty() {
+            crate::rpc::emit_progress(&text);
+            line.clear();
+        }
+        Ok(())
+    }
+}
+
+pub(crate) fn init_context(multi: MultiProgress, migrating: bool, validating: bool) -> Result<()> {
     let home_dir = dirs::home_dir().context("无法获取 HOME 环境变量")?;
 
     debug!(

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,6 +22,7 @@ mod generate;
 mod init;
 mod prelude;
 mod ren;
+mod rpc;
 mod test;
 mod tuack_lib;
 mod utils;
@@ -62,9 +63,18 @@ enum Commands {
     Doc(DocArgs),
     /// 开发工具
     Develop(develop::DevelopArgs),
+    /// 以 JSON-RPC 方式运行（供图形前端使用）
+    #[command(version, hide = true)]
+    Rpc,
 }
 
 async fn tuack_ng(cli: Cli) -> Result<()> {
+    // RPC 模式自行初始化（日志/进度改道、按请求重建上下文），
+    // 不走常规的单次 CLI 初始化
+    if matches!(cli.command, Commands::Rpc) {
+        return rpc::main().await;
+    }
+
     init::init(
         &{
             #[cfg(debug_assertions)]
@@ -90,6 +100,7 @@ async fn tuack_ng(cli: Cli) -> Result<()> {
         Commands::Dump(args) => dump::main(args),
         Commands::Doc(args) => doc::main(args),
         Commands::Develop(args) => develop::main(args),
+        Commands::Rpc => rpc::main().await,
     }
 }
 

--- a/src/ren.rs
+++ b/src/ren.rs
@@ -7,23 +7,23 @@ pub mod template;
 pub mod tools;
 pub mod unwrap;
 pub mod utils;
-use crate::ren::unwrap::unwrap_template;
 use crate::ren::processors::process_ast;
-use crate::tuack_lib::ren::base::Checker;
-use crate::tuack_lib::ren::base::Compiler;
 use crate::ren::renderers::markdown::MarkdownChecker;
 use crate::ren::renderers::markdown::MarkdownCompiler;
 use crate::ren::renderers::typst::{TypstChecker, TypstCompiler};
+use crate::ren::unwrap::unwrap_template;
 use crate::ren::utils::{process_image_urls, process_images_with_unique_ids};
+use crate::tuack_lib::ren::base::Checker;
+use crate::tuack_lib::ren::base::Compiler;
 use clap::Args;
 use indexmap::IndexMap;
 use manifest::TargetType;
 use manifest::TemplateManifest;
-use tuack_ng_parser::ast::Document;
-use tuack_ng_parser::parse;
 use opener::open;
 use owo_colors::OwoColorize;
 use std::time::Duration;
+use tuack_ng_parser::ast::Document;
+use tuack_ng_parser::parse;
 
 use crate::ren::template::render_template;
 
@@ -34,7 +34,8 @@ use indicatif::ProgressBar;
 use crate::context;
 use crate::context::{CurrentLocation, gctx};
 
-#[derive(Args, Debug)]
+#[derive(Args, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
 #[command(version)]
 pub struct RenArgs {
     /// 渲染目标模板

--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -1,0 +1,270 @@
+//! JSON-RPC（stdio）服务。
+//!
+//! 供 GUI 前端以结构化方式驱动 tuack-ng：进程常驻，请求/响应与通知
+//! 均为行分隔的 JSON-RPC 2.0 消息，通过 stdin/stdout 传输。
+//!
+//! 本模块同时承担「输出改道」职责：RPC 模式下 `msg!`/`emsg!`、log
+//! 与进度条绘制统一转为 `output`/`progress` 通知，避免污染 stdout。
+
+use std::io::BufRead as _;
+use std::io::Write as _;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Mutex, OnceLock};
+
+static RPC_ENABLED: AtomicBool = AtomicBool::new(false);
+/// 当前 run 是否保留 ANSI 颜色（由请求参数 color 控制）
+static RPC_COLOR: AtomicBool = AtomicBool::new(false);
+static RPC_STDOUT: OnceLock<Mutex<std::io::Stdout>> = OnceLock::new();
+
+pub(crate) fn set_color(color: bool) {
+    RPC_COLOR.store(color, Ordering::SeqCst);
+}
+
+/// 当前 run 是否要求彩色输出（供 supports_color 等询问）
+pub fn is_color_enabled() -> bool {
+    RPC_COLOR.load(Ordering::SeqCst)
+}
+
+/// 进入 RPC 模式：接管 stdout（着色剥离在 emit_* 中进行）。
+pub fn enable() {
+    RPC_ENABLED.store(true, Ordering::SeqCst);
+    let _ = RPC_STDOUT.set(Mutex::new(std::io::stdout()));
+}
+
+pub fn is_enabled() -> bool {
+    RPC_ENABLED.load(Ordering::SeqCst)
+}
+
+fn send(value: &serde_json::Value) {
+    if let Some(out) = RPC_STDOUT.get() {
+        let mut guard = out.lock().unwrap();
+        let _ = serde_json::to_writer(&mut *guard, value);
+        let _ = guard.write_all(b"\n");
+        let _ = guard.flush();
+    }
+}
+
+/// 剥离常见 ANSI 转义（颜色/光标），RPC 通知应为纯文本。
+fn strip_ansi(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    let mut chars = s.chars().peekable();
+    while let Some(c) = chars.next() {
+        if c == '\x1b' {
+            match chars.peek() {
+                Some('[') => {
+                    chars.next();
+                    // CSI：跳过参数字节直到终止字节（@..~）
+                    for p in chars.by_ref() {
+                        if ('@'..='~').contains(&p) {
+                            break;
+                        }
+                    }
+                }
+                Some(']') => {
+                    chars.next();
+                    // OSC：跳到 BEL 或 ST（ESC \）
+                    let mut prev = '\0';
+                    for p in chars.by_ref() {
+                        if p == '\x07' || (p == '\\' && prev == '\x1b') {
+                            break;
+                        }
+                        prev = p;
+                    }
+                }
+                _ => {}
+            }
+        } else {
+            out.push(c);
+        }
+    }
+    out
+}
+
+/// 把 `msg!`/`emsg!` 的输出改道为 `output` 通知。
+/// 返回 true 表示已作为通知发出（调用方不应再直接打印）。
+pub fn emit_output(stream: &str, text: &str) -> bool {
+    if !is_enabled() {
+        return false;
+    }
+    send(&serde_json::json!({
+        "jsonrpc": "2.0",
+        "method": "output",
+        "params": {
+            "stream": stream,
+            "text": if RPC_COLOR.load(Ordering::SeqCst) { text.to_string() } else { strip_ansi(text) },
+        },
+    }));
+    true
+}
+
+/// 发出 `progress` 通知（进度条捕获，见 init.rs 的 RpcTermLike）。
+pub fn emit_progress(text: &str) {
+    if !is_enabled() {
+        return;
+    }
+    send(&serde_json::json!({
+        "jsonrpc": "2.0",
+        "method": "progress",
+        "params": {
+            "text": if RPC_COLOR.load(Ordering::SeqCst) { text.to_string() } else { strip_ansi(text) },
+        },
+    }));
+}
+
+// ---------- 请求分发 ----------
+
+/// RPC 的 `run` 方法：语义化命令参数（与 CLI 各 Args 结构体同构）
+#[derive(serde::Deserialize)]
+#[serde(
+    tag = "command",
+    rename_all = "snake_case",
+    rename_all_fields = "snake_case"
+)]
+pub enum RpcCommand {
+    Ren(crate::ren::RenArgs),
+    Gen(crate::generate::GenArgs),
+    Test(crate::test::TestArgs),
+    Conf(crate::conf::ConfArgs),
+    Dmk(crate::dmk::DmkArgs),
+    Validate(crate::validate::ValidateArgs),
+    Dump(crate::dump::DumpArgs),
+    Doc(crate::doc::DocArgs),
+}
+
+#[derive(serde::Deserialize)]
+struct RunParams {
+    cwd: String,
+    /// 输出通知是否保留 ANSI 颜色（默认 false，前端若用终端渲染可开启）
+    #[serde(default)]
+    color: bool,
+    #[serde(flatten)]
+    command: RpcCommand,
+}
+
+fn respond(id: &serde_json::Value, body: serde_json::Value) {
+    // 通知型请求（无 id）不回复
+    if id.is_null() {
+        return;
+    }
+    let mut msg = serde_json::Map::new();
+    msg.insert("jsonrpc".to_string(), "2.0".into());
+    msg.insert("id".to_string(), id.clone());
+    if let Some(obj) = body.as_object() {
+        for (k, v) in obj {
+            msg.insert(k.clone(), v.clone());
+        }
+    }
+    send(&serde_json::Value::Object(msg));
+}
+
+async fn run_once(multi: &indicatif::MultiProgress, params: RunParams) -> anyhow::Result<()> {
+    set_color(params.color);
+    std::env::set_current_dir(&params.cwd)?;
+
+    // 与 CLI 初始化相同的跳过/迁移/校验逻辑
+    let skip = matches!(
+        &params.command,
+        RpcCommand::Gen(crate::generate::GenArgs {
+            target: crate::generate::Targets::Complete(_)
+        })
+    );
+    let migrating = matches!(
+        &params.command,
+        RpcCommand::Conf(crate::conf::ConfArgs {
+            target: crate::conf::Targets::Migrate
+        })
+    );
+    let validating = matches!(
+        &params.command,
+        RpcCommand::Doc(crate::doc::DocArgs {
+            target: crate::doc::Targets::Validate
+        })
+    );
+    if !skip {
+        crate::init::init_context(multi.clone(), migrating, validating)?;
+    }
+
+    match params.command {
+        RpcCommand::Ren(args) => crate::ren::main(args),
+        RpcCommand::Gen(args) => crate::generate::main(args),
+        RpcCommand::Test(args) => crate::test::main(args).await,
+        RpcCommand::Conf(args) => crate::conf::main(args),
+        RpcCommand::Dmk(args) => crate::dmk::main(args).await,
+        RpcCommand::Validate(args) => crate::validate::main(args).await,
+        RpcCommand::Dump(args) => crate::dump::main(args),
+        RpcCommand::Doc(args) => crate::doc::main(args),
+    }
+}
+
+/// JSON-RPC 主循环：stdin 读行 → 分发 → stdout 回复。
+pub async fn main() -> anyhow::Result<()> {
+    enable();
+
+    // panic 也改道为通知，避免污染 stdout 流
+    let default_hook = std::panic::take_hook();
+    std::panic::set_hook(Box::new(move |info| {
+        let location = info
+            .location()
+            .map(|l| format!("{}:{}:{}", l.file(), l.line(), l.column()))
+            .unwrap_or_default();
+        let _ = emit_output("stderr", &format!("panic: {} @ {location}", info));
+        default_hook(info);
+    }));
+
+    let multi = crate::init::init_log(&false)?;
+    log::info!("rpc booting up");
+
+    let stdin = std::io::stdin();
+    for line in stdin.lock().lines() {
+        let Ok(line) = line else { break };
+        let line = line.trim();
+        if line.is_empty() {
+            continue;
+        }
+        let Ok(req) = serde_json::from_str::<serde_json::Value>(line) else {
+            send(
+                &serde_json::json!({"jsonrpc":"2.0","id":null,"error":{"code":-32700,"message":"parse error"}}),
+            );
+            continue;
+        };
+        let id = req.get("id").cloned().unwrap_or(serde_json::Value::Null);
+        let method = req.get("method").and_then(|m| m.as_str()).unwrap_or("");
+
+        match method {
+            "ping" => respond(&id, serde_json::json!({ "result": "pong" })),
+            "exit" => {
+                respond(&id, serde_json::json!({ "result": null }));
+                break;
+            }
+            "run" => {
+                let params: RunParams = match serde_json::from_value(req["params"].clone()) {
+                    Ok(p) => p,
+                    Err(e) => {
+                        respond(
+                            &id,
+                            serde_json::json!({"error":{"code":-32602,"message":format!("invalid params: {e}")}}),
+                        );
+                        continue;
+                    }
+                };
+                let started = std::time::Instant::now();
+                match run_once(&multi, params).await {
+                    Ok(()) => respond(
+                        &id,
+                        serde_json::json!({"result":{"exit_code":0,"duration_ms":started.elapsed().as_millis()}}),
+                    ),
+                    Err(e) => respond(
+                        &id,
+                        serde_json::json!({"error":{"code":-32000,"message":format!("{e:#}")}}),
+                    ),
+                }
+            }
+            _ => respond(
+                &id,
+                serde_json::json!({"error":{"code":-32601,"message":format!("method not found: {method}")}}),
+            ),
+        }
+    }
+
+    Ok(())
+}

--- a/src/test.rs
+++ b/src/test.rs
@@ -19,7 +19,8 @@ use crate::utils::compilers::cpp::CppRunner;
 use crate::utils::compilers::general::*;
 use crate::utils::duration::format_duration;
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
 pub enum Target {
     /// 正式测试数据
     Data,
@@ -79,7 +80,8 @@ pub struct ProblemTestResult {
     pub full_score: u32,
 }
 
-#[derive(Args, Debug)]
+#[derive(Args, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
 #[command(version)]
 pub struct TestArgs {
     /// 目标类型

--- a/src/utils/message.rs
+++ b/src/utils/message.rs
@@ -3,23 +3,44 @@ use anstream::{AutoStream, stderr, stdout};
 pub use owo_colors::OwoColorize;
 
 pub fn supports_color() -> bool {
+    // RPC 模式由请求参数 color 决定；否则按 anstream 的终端检测
+    if crate::rpc::is_enabled() {
+        return crate::rpc::is_color_enabled();
+    }
     !matches!(
         anstream::stdout().current_choice(),
         anstream::ColorChoice::Never
     )
 }
 
+/// 实际写入 stdout/stderr（绕过宏的上下文暂停逻辑）
+pub fn raw_print(stream: &str, text: &str) {
+    if stream == "stderr" {
+        anstream::eprintln!("{}", text);
+    } else {
+        anstream::println!("{}", text);
+    }
+}
+
 #[macro_export]
 macro_rules! _internal_print {
-    ($stream:ident, $($arg:tt)*) => {
-        if let Some(ctx) = $crate::context::GLOBAL_CONTEXT.get() {
-            ctx.multiprogress.suspend(|| {
-                anstream::$stream!($($arg)*);
+    ($stream:ident, $($arg:tt)*) => {{
+        let __text = ::std::format!($($arg)*);
+        let __stream = if stringify!($stream) == "eprintln" {
+            "stderr"
+        } else {
+            "stdout"
+        };
+        if $crate::rpc::emit_output(__stream, &__text) {
+            // JSON-RPC 模式：已作为 output 通知发出
+        } else if let Some(__ctx) = $crate::context::try_gctx() {
+            __ctx.multiprogress.suspend(|| {
+                $crate::utils::message::raw_print(__stream, &__text);
             });
         } else {
-            anstream::$stream!($($arg)*);
+            $crate::utils::message::raw_print(__stream, &__text);
         }
-    };
+    }};
 }
 
 #[macro_export]

--- a/src/validate.rs
+++ b/src/validate.rs
@@ -10,7 +10,8 @@ use crate::tuack_lib::data::Data;
 use crate::tuack_lib::utils::testlib::{Validator, ValidatorResult};
 use crate::utils::validators::cpp::CppValidator;
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
 pub enum Target {
     /// 正式测试数据
     Data,
@@ -18,7 +19,8 @@ pub enum Target {
     Sample,
 }
 
-#[derive(Args, Debug)]
+#[derive(Args, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
 #[command(version)]
 pub struct ValidateArgs {
     /// 目标类型


### PR DESCRIPTION
## 这个 Pull Request 做了什么？

为 Tuack-NG 新增 JSON-RPC（stdio）服务，供图形前端（Tuack-GUI）以结构化方式驱动：

- 新增隐藏子命令 `rpc`：常驻进程，行分隔 JSON-RPC 2.0，方法 `ping`/`run`/`exit`；`run` 接收语义化参数（与 CLI Args 同构，内部标签 `{command, ...}`），响应携带 `exit_code`/`duration_ms`
- 输出改道：`msg!`/`emsg!`、log4rs 日志、indicatif 进度绘制统一转 `output`/`progress` 通知（panic 亦改道），不污染 stdout
- `run` 参数支持按请求的 `color` 开关（默认 false 剥离 ANSI；true 时原样保留，供前端终端渲染）
- 全局上下文支持按请求重建（`RwLock` + `Box::leak`），`run` 每次切换 cwd 并重新加载配置，`gctx()` 调用点零改动
- 各命令 Args 结构体及嵌套枚举派生 serde（值枚举 snake_case、子命令枚举内部标签）；doc 三处直接 `println!` 改为 `msg!`

## 截图/录屏

本地实测记录（debug 构建，`gen contest demo` 为 CLI 预置工程）：

<img width="2734" height="574" alt="image" src="https://github.com/user-attachments/assets/efd7c873-82fb-4081-b824-e1e3c688769e" />

<img width="2707" height="706" alt="image" src="https://github.com/user-attachments/assets/cf61b907-f74d-4476-9e0b-fe56250bc61d" />

<img width="3000" height="594" alt="image" src="https://github.com/user-attachments/assets/4a4091ec-8af7-4ffe-b90f-a747cd2b36cb" />

<img width="2985" height="327" alt="image" src="https://github.com/user-attachments/assets/aef03129-699e-4d1b-abcf-d71cd44fd2b8" />



## 实现思路

- **传输**：LSP 风格的 stdio 行分隔 JSON-RPC，避免端口管理与鉴权问题；GUI 侧直接 `spawn(tuack-ng rpc)` 即可。
- **语义化参数**：直接给现有 clap Args 结构体派生 serde（值枚举 `rename_all = "snake_case"`，子命令枚举用内部标签 `#[serde(tag = "type")]`），RPC 参数与 CLI 结构一一对应，不引入第二套命令模型。
- **上下文重建**：`GLOBAL_CONTEXT` 由 `OnceLock` 改为 `RwLock<Option<&'static Context>>`；旧上下文 `Box::leak` 保活避免悬垂，`gctx()` 返回类型不变，54 个调用点零改动。
- **输出改道**：`_internal_print!` 宏先经 `rpc::emit_output` 判定；RPC 模式 log4rs 换自定义 appender、indicatif 换捕获式 `TermLike`（v1 多进度条仅保留最近一行）；`supports_color()` 在 RPC 模式改由请求的 `color` 开关决定。

## 破坏性变更

- `setup_context` 语义由「仅可初始化一次」变为「可重建」（`OnceLock` → `RwLock`）；`gctx()` 签名与行为不变，现有调用方无感知。
- 新增隐藏子命令 `rpc`，不影响现有 CLI 行为。
- doc 模块三处 `println!` → `msg!`，输出流向不变（仍为 stdout）。
- 已知简化：`run` 串行处理（不并发）；RPC 模式固定非 verbose 日志级别。

## 检查清单

- [x] 我阅读并已经在本地测试过这个 PR，确保欲实现的功能或修复的问题能正常工作。

已本地测试（debug 构建）：`ping`/`run`/`exit` 、输出通知、`-32602`/`-32000`/`-32601` 错误路径、`color` 开关两种模式。
